### PR TITLE
Enable add commands for spells and items

### DIFF
--- a/src/bot/bot.go
+++ b/src/bot/bot.go
@@ -13,6 +13,9 @@ import (
 )
 
 var BotToken string
+var DumpChannelID string
+var SpellFormURL string
+var ItemFormURL string
 
 func checkNilErr(e error) {
 	if e != nil {
@@ -48,6 +51,30 @@ func newMessage(discord *discordgo.Session, message *discordgo.MessageCreate) {
 	if message.Author.ID == discord.State.User.ID {
 		return
 	}
+	// check to see if we recieved an embed from the dump channel
+	if message.ChannelID == DumpChannelID {
+		// in the case where we're in the dump channel we now that we have the embed sent from the webhook
+		// so from there we send the embed over to the wrapping function to handle either case of spell or item
+		switch message.Embeds[0].Title {
+		case "Spell":
+			err := rest.AddSpell(message.Embeds[0])
+			if err != nil {
+				discord.ChannelMessageSend(message.ChannelID, "something went wrong with adding the spell")
+				return
+			}
+			discord.ChannelMessageSend(message.ChannelID, "addition of spell was successful")
+		case "Magic Item":
+			err := rest.AddItem(message.Embeds[0])
+			if err != nil {
+				fmt.Printf("ERROR: unable to add new item, %v", err.Error())
+				discord.ChannelMessageSend(message.ChannelID, "something went wrong with adding the magic item")
+				return
+			}
+			discord.ChannelMessageSend(message.ChannelID, "addition of magic item was successful")
+		}
+		return
+	}
+
 	// split the message and compare to see if the first substring in the message matches the command in the switch statement
 	splitMsg := strings.Split(message.Content, " ")
 
@@ -83,5 +110,9 @@ func newMessage(discord *discordgo.Session, message *discordgo.MessageCreate) {
 			return
 		}
 		discord.ChannelMessageSendEmbed(message.ChannelID, embed)
+	case "!addspell":
+		discord.ChannelMessageSend(message.ChannelID, fmt.Sprintf("Fill out the following form: %v note that it may take a little while for your added spell to be searchable.", SpellFormURL))
+	case "!additem":
+		discord.ChannelMessageSend(message.ChannelID, fmt.Sprintf("Fill out the following form: %v note that it may take a little while for your item to be searchable.", ItemFormURL))
 	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -15,5 +15,8 @@ func main() {
 		return
 	}
 	bot.BotToken = os.Getenv("DISCORD_BOT_TOKEN")
+	bot.DumpChannelID = os.Getenv("DUMP_CHANNEL_ID")
+	bot.SpellFormURL = os.Getenv("SPELL_FORM_URL")
+	bot.ItemFormURL = os.Getenv("ITEM_FORM_URL")
 	bot.Run() // simply call for the bot to be ran
 }

--- a/src/rest/magicItem.go
+++ b/src/rest/magicItem.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"wikiBot/src/cache"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -76,4 +77,45 @@ func formatVariants(values []Variant) string {
 		}
 	}
 	return builder.String()
+}
+
+func AddItem(itemEmbed *discordgo.MessageEmbed) error {
+	// first start by defining all the properties we'll need to set
+	var itemName string
+	var itemFileName string
+	var equipmentCategory EquipmentCategory
+	var itemRarity Rarity
+	itemVariants := make([]Variant, 0)
+	itemDesc := make([]string, 0)
+
+	// set the fields, we now the order in this case so no need to loop
+	itemName = strings.ReplaceAll(itemEmbed.Fields[0].Value, "-", " ")
+	itemFileName = itemEmbed.Fields[0].Value
+	itemDesc = append(itemDesc, itemEmbed.Fields[1].Value)
+	equipmentCategory = EquipmentCategory{
+		Index: strings.ToLower(strings.ReplaceAll(itemEmbed.Fields[2].Value, " ", "-")),
+		Name:  itemEmbed.Fields[2].Value,
+	}
+	itemRarity = Rarity{Name: itemEmbed.Fields[3].Value}
+
+	// create the item entity
+	itemEntity := MagicItem{
+		Name:     itemName,
+		EquipCat: equipmentCategory,
+		Rarity:   itemRarity,
+		Variants: itemVariants,
+		Desc:     itemDesc,
+	}
+	// now try to encode the data
+	encodedItem, err := json.Marshal(itemEntity)
+	if err != nil {
+		fmt.Printf("There was an issue encoding the new item %v\n", itemName)
+		return err
+	}
+	err = cache.SetObject(fmt.Sprintf("magic-items/%v", itemFileName), encodedItem)
+
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/rest/spell.go
+++ b/src/rest/spell.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"wikiBot/src/cache"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -104,6 +105,11 @@ func GetSpell(spell string) (*discordgo.MessageEmbed, error) {
 				Value:  strconv.FormatBool(spellEntity.Ritual),
 				Inline: false,
 			},
+			{
+				Name:   "Concentration",
+				Value:  strconv.FormatBool(spellEntity.Concentration),
+				Inline: false,
+			},
 		},
 	}
 
@@ -130,4 +136,92 @@ func formatComponents(values []string) string {
 		}
 	}
 	return builder.String()
+}
+
+func AddSpell(spellEmbed *discordgo.MessageEmbed) error {
+	// we know that this thing is a spell so what we gotta do is set up all the variables we need to define the spell
+	var spellFileName string
+	higherLevel := make([]string, 0)
+	var spellName string
+	desc := make([]string, 0)
+	var spellRange string
+	components := make([]string, 0)
+	var isRitual bool = false
+	var spellDuration string
+	var isConcentration bool = false
+	var castingTime string
+	var level int
+	// attacktype and damage we'll set as constant values for now
+	spellAttack := ""
+	spellDamage := Damage{DamageType: DamageType{Name: "damage"}, DamageAtCharacterLevel: DamageAtCharacterLevel{First: "1", Fifth: "5", Eleventh: "11", Seventeenth: "17"}}
+	spellSchool := MagicSchool{Name: "placeholder"}
+	spellClasses := make([]Class, 0)
+	var spellMaterial string
+
+	// now we loop through each field and set the according variable
+	for _, field := range spellEmbed.Fields {
+		// TODO: Fix this shit, make it into a look up table or something
+
+		if field.Name == "Spell Name" {
+			spellFileName = field.Value
+			spellName = strings.ReplaceAll(field.Value, "-", " ")
+		} else if field.Name == "Description" {
+			desc = append(desc, field.Value)
+		} else if field.Name == "Higher Level" {
+			higherLevel = append(higherLevel, field.Value)
+		} else if field.Name == "Range" {
+			spellRange = field.Value
+		} else if strings.Contains(field.Name, "Components") {
+			components = append(components, field.Value)
+		} else if field.Name == "Ritual" && field.Value == "yes" {
+			isRitual = true
+		} else if field.Name == "Concentration" && field.Value == "yes" {
+			isConcentration = true
+		} else if field.Name == "Casting time" {
+			castingTime = field.Value
+		} else if field.Name == "Level" {
+			parsedLevel, err := strconv.ParseInt(field.Value, 10, 64)
+			level = int(parsedLevel)
+			if err != nil {
+				fmt.Println("Error adding spell. Unable to parse spell level")
+				return err
+			}
+		} else if field.Name == "School" {
+			spellSchool.Name = field.Value
+		} else if strings.Contains(field.Name, "Classes") {
+			spellClasses = append(spellClasses, Class{Name: field.Value})
+		} else if field.Name == "Material" {
+			spellMaterial = field.Value
+		} else if field.Name == "Duration" {
+			spellDuration = field.Value
+		}
+	}
+	// once all properties are set we generate the spell instance and encode into json
+	newSpellEntity := Spell{
+		HigherLevel:   higherLevel,
+		Name:          spellName,
+		Desc:          desc,
+		Range:         spellRange,
+		Components:    components,
+		Ritual:        isRitual,
+		Duration:      spellDuration,
+		Concentration: isConcentration,
+		CastingTime:   castingTime,
+		Level:         level,
+		AttackType:    spellAttack,
+		SpellDamage:   spellDamage,
+		School:        spellSchool,
+		Classes:       spellClasses,
+		Material:      spellMaterial,
+	}
+	// now that the entity has been made we need to encode it into json
+	encodedSpell, err := json.Marshal(newSpellEntity)
+	if err != nil {
+		return err
+	}
+	err = cache.SetObject(fmt.Sprintf("spells/%v", spellFileName), encodedSpell)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Adding new spells and magical items have been added as a feature in this pr. The way things work is a user enters !addspell or 
!additem which will then return a link to a google form for them to figure out. Once the form is submitted a webhook will be triggered that will then post the form results to a discord channel that the bot will read and add the information to the cache accordingly. Genuinely feel pretty good about these changes, except for the else if chain, that was messy